### PR TITLE
Set the intervalstyle output format to ISO 8601

### DIFF
--- a/azuredbmock/00-initialize.sql
+++ b/azuredbmock/00-initialize.sql
@@ -35,3 +35,6 @@ GRANT CREATE ON DATABASE xxx_db_timetables_name_xxx TO xxx_db_hasura_username_xx
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- interval outputs by default are using the sql format ('3 4:05:06'). Here we are switching to ISO 8601 format ('P3DT4H5M6S')
+ALTER DATABASE xxx_db_timetables_name_xxx SET intervalstyle = 'iso_8601';


### PR DESCRIPTION
Interval outputs by default are using the sql format ('3 4:05:06'). Here we are switching to ISO 8601 format ('P3DT4H5M6S')

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-postgres/12)
<!-- Reviewable:end -->
