### PR TITLE
Remove unused `postgis` extension from timetables database

### DIFF
--- a/azuredbmock/00-initialize.sql
+++ b/azuredbmock/00-initialize.sql
@@ -39,7 +39,6 @@ GRANT CREATE ON DATABASE xxx_db_timetables_name_xxx TO xxx_db_hasura_username_xx
 -- switch database context to timetables db to be able to add extensions there
 \connect xxx_db_timetables_name_xxx;
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
-CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE EXTENSION IF NOT EXISTS btree_gist;
 
 -- interval outputs by default are using the sql format ('3 4:05:06'). Here we are switching to ISO 8601 format ('P3DT4H5M6S')


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-postgres/22)
<!-- Reviewable:end -->
