### PR TITLE
Fix default permissions for stopdb hasura user

### DIFF
--- a/azuredbmock/00-initialize.sql
+++ b/azuredbmock/00-initialize.sql
@@ -66,8 +66,8 @@ GRANT CONNECT ON DATABASE xxx_db_tiamat_name_xxx TO xxx_db_hasura_username_xxx;
 
 GRANT USAGE ON SCHEMA public TO xxx_db_hasura_username_xxx;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO xxx_db_hasura_username_xxx;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO xxx_db_hasura_username_xxx;
+ALTER DEFAULT PRIVILEGES FOR USER xxx_db_tiamat_username_xxx IN SCHEMA public GRANT SELECT ON TABLES TO xxx_db_hasura_username_xxx;
 
 GRANT USAGE ON SCHEMA topology TO xxx_db_hasura_username_xxx;
 GRANT SELECT ON ALL TABLES IN SCHEMA topology TO xxx_db_hasura_username_xxx;
-ALTER DEFAULT PRIVILEGES IN SCHEMA topology GRANT SELECT ON TABLES TO xxx_db_hasura_username_xxx;
+ALTER DEFAULT PRIVILEGES FOR USER xxx_db_tiamat_username_xxx IN SCHEMA topology GRANT SELECT ON TABLES TO xxx_db_hasura_username_xxx;


### PR DESCRIPTION
Set default permissions for tables created by Tiamat user, not by superuser.