### PR TITLE
Update Github Workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,11 +8,11 @@ on:
 jobs:
   push_to_registry:
     name: Build & Push docker image to dockerhub
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get metadata as environment variables
         uses: HSLdevcom/jore4-tools/github-actions/extract-metadata@extract-metadata-v1
@@ -40,7 +40,7 @@ jobs:
             -t $IMAGE_NAME:azuredbmock-$COMMIT_ID ./azuredbmock
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.JORE4_DOCKERHUB_USER }}
           password: ${{ secrets.JORE4_DOCKERHUB_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
   test-docker-images:
     name: verify that the docker images work
     needs: push_to_registry
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       POSTGRES_DB: testdb
       POSTGRES_USER: user
@@ -149,7 +149,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get metadata as environment variables
         uses: HSLdevcom/jore4-tools/github-actions/extract-metadata@extract-metadata-v1
@@ -174,18 +174,15 @@ jobs:
   run_e2e_tests:
     needs: push_to_registry
     name: Run E2E tests
-    runs-on: ubuntu-latest-4-cores
+    # These must run on ubuntu 22.04 or older.
+    # The MS SQL server used by jore4-jore3-importer,
+    # does not run on Linux kernels newer than 6.6.x.
+    runs-on: ubuntu-22.04
     steps:
       - name: Extract metadata to env variables
         uses: HSLdevcom/jore4-tools/github-actions/extract-metadata@extract-metadata-v1
 
-      - name: start e2e env
-        uses: HSLdevcom/jore4-tools/github-actions/setup-e2e-environment@setup-e2e-environment-v4
+      - name: Run e2e tests
+        uses: HSLdevcom/jore4-tools/github-actions/run-ci@main
         with:
           testdb_version: "${{ env.IMAGE_NAME }}:azuredbmock-${{ env.COMMIT_ID }}"
-
-      - name: Seed infrastructure links
-        uses: HSLdevcom/jore4-tools/github-actions/seed-infrastructure-links@seed-infrastructure-links-v2
-
-      - name: Run e2e tests
-        uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v1

--- a/.github/workflows/check-renovatebot-config.yml
+++ b/.github/workflows/check-renovatebot-config.yml
@@ -6,12 +6,12 @@ on:
 jobs:
   validate:
     name: Validate renovatebot config
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Validate
-        uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.3
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.0
         with:
           config_file_path: .github/renovate.json5

--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -8,11 +8,11 @@ on:
 jobs:
   test-docker-compose:
     name: verify docker-compose setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Start postgres databases in docker-compose
         run: docker-compose up -d

--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Start postgres databases in docker-compose
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Verify that mapmatching database is up and can be connected to
         uses: HSLdevcom/jore4-tools/github-actions/healthcheck@healthcheck-v1


### PR DESCRIPTION
* Run on Ubuntu 24.04 or 22.04 for tasks requiring e2e env
* Update actions/checkout 3 → 4
* Update suzuki-shunsuke/github-action-renovate-config-validator to 1.1.0
* Use run-ci task instead of manual e2e run
* Use `docker compose` instead of `docker-compose`